### PR TITLE
Upgrading alerts API to 0.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,27 @@
-test-output/
+*.class
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# maven target directories
 target/
-.settings/
+
+# IntelliJ
+.idea
+*.iml
+
+# Eclipse
 .project
 .classpath
+.settings
+
+# KDE
+.directory

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <hawkular.metrics.version>0.8.0.Final</hawkular.metrics.version>
     <hawkular.inventory.version>0.3.2.Final</hawkular.inventory.version>
     <hawkular.inventory.json.helper.version>0.3.2.Final</hawkular.inventory.json.helper.version>
-    <hawkular.alerts.version>0.5.0-SNAPSHOT</hawkular.alerts.version>
+    <hawkular.alerts.version>0.6.0-SNAPSHOT</hawkular.alerts.version>
     <resteasy.version>3.0.8.Final</resteasy.version>
     <resteasy.jackson2.provider.version>3.0.8.Final</resteasy.jackson2.provider.version>
     <org.jboss.logging.version>3.3.0.Final</org.jboss.logging.version>

--- a/src/main/java/org/hawkular/client/alert/AlertsClient.java
+++ b/src/main/java/org/hawkular/client/alert/AlertsClient.java
@@ -22,10 +22,10 @@ import java.util.Set;
 
 import org.hawkular.alerts.api.json.GroupMemberInfo;
 import org.hawkular.alerts.api.json.UnorphanMemberInfo;
-import org.hawkular.alerts.api.model.event.Alert;
 import org.hawkular.alerts.api.model.condition.Condition;
 import org.hawkular.alerts.api.model.dampening.Dampening;
 import org.hawkular.alerts.api.model.data.Data;
+import org.hawkular.alerts.api.model.event.Alert;
 import org.hawkular.alerts.api.model.trigger.Mode;
 import org.hawkular.alerts.api.model.trigger.Trigger;
 import org.hawkular.client.ClientResponse;

--- a/src/main/java/org/hawkular/client/alert/AlertsClient.java
+++ b/src/main/java/org/hawkular/client/alert/AlertsClient.java
@@ -22,10 +22,10 @@ import java.util.Set;
 
 import org.hawkular.alerts.api.json.GroupMemberInfo;
 import org.hawkular.alerts.api.json.UnorphanMemberInfo;
-import org.hawkular.alerts.api.model.condition.Alert;
+import org.hawkular.alerts.api.model.event.Alert;
 import org.hawkular.alerts.api.model.condition.Condition;
 import org.hawkular.alerts.api.model.dampening.Dampening;
-import org.hawkular.alerts.api.model.data.MixedData;
+import org.hawkular.alerts.api.model.data.Data;
 import org.hawkular.alerts.api.model.trigger.Mode;
 import org.hawkular.alerts.api.model.trigger.Trigger;
 import org.hawkular.client.ClientResponse;
@@ -148,7 +148,7 @@ public interface AlertsClient {
 
     ClientResponse<String> resolveAlerts(String alertIds, String resolvedBy, String resolvedNotes);
 
-    ClientResponse<String> sendData(MixedData mixedData);
+    ClientResponse<String> sendData(Data data);
 
     ClientResponse<String> reloadAlerts();
 

--- a/src/main/java/org/hawkular/client/alert/AlertsClientImpl.java
+++ b/src/main/java/org/hawkular/client/alert/AlertsClientImpl.java
@@ -23,10 +23,10 @@ import java.util.Set;
 
 import org.hawkular.alerts.api.json.GroupMemberInfo;
 import org.hawkular.alerts.api.json.UnorphanMemberInfo;
-import org.hawkular.alerts.api.model.condition.Alert;
+import org.hawkular.alerts.api.model.event.Alert;
 import org.hawkular.alerts.api.model.condition.Condition;
 import org.hawkular.alerts.api.model.dampening.Dampening;
-import org.hawkular.alerts.api.model.data.MixedData;
+import org.hawkular.alerts.api.model.data.Data;
 import org.hawkular.alerts.api.model.trigger.Mode;
 import org.hawkular.alerts.api.model.trigger.Trigger;
 import org.hawkular.client.BaseClient;
@@ -295,8 +295,8 @@ public class AlertsClientImpl extends BaseClient<AlertsRestApi> implements Alert
     }
 
     @Override
-    public ClientResponse<String> sendData(MixedData mixedData) {
-        return new ClientResponse<String>(String.class, restApi().sendData(mixedData),
+    public ClientResponse<String> sendData(Data data) {
+        return new ClientResponse<String>(String.class, restApi().sendData(data),
                 RESPONSE_CODE.UPDATE_SUCCESS.value());
     }
 

--- a/src/main/java/org/hawkular/client/alert/AlertsClientImpl.java
+++ b/src/main/java/org/hawkular/client/alert/AlertsClientImpl.java
@@ -23,10 +23,10 @@ import java.util.Set;
 
 import org.hawkular.alerts.api.json.GroupMemberInfo;
 import org.hawkular.alerts.api.json.UnorphanMemberInfo;
-import org.hawkular.alerts.api.model.event.Alert;
 import org.hawkular.alerts.api.model.condition.Condition;
 import org.hawkular.alerts.api.model.dampening.Dampening;
 import org.hawkular.alerts.api.model.data.Data;
+import org.hawkular.alerts.api.model.event.Alert;
 import org.hawkular.alerts.api.model.trigger.Mode;
 import org.hawkular.alerts.api.model.trigger.Trigger;
 import org.hawkular.client.BaseClient;

--- a/src/main/java/org/hawkular/client/alert/AlertsRestApi.java
+++ b/src/main/java/org/hawkular/client/alert/AlertsRestApi.java
@@ -35,7 +35,7 @@ import org.hawkular.alerts.api.json.GroupMemberInfo;
 import org.hawkular.alerts.api.json.UnorphanMemberInfo;
 import org.hawkular.alerts.api.model.condition.Condition;
 import org.hawkular.alerts.api.model.dampening.Dampening;
-import org.hawkular.alerts.api.model.data.MixedData;
+import org.hawkular.alerts.api.model.data.Data;
 import org.hawkular.alerts.api.model.trigger.Mode;
 import org.hawkular.alerts.api.model.trigger.Trigger;
 
@@ -229,7 +229,7 @@ public interface AlertsRestApi {
 
     @POST
     @Path("/data")
-    Response sendData(final MixedData mixedData);
+    Response sendData(final Data mixedData);
 
     @GET
     @Path("/reload")


### PR DESCRIPTION
Shortly we will upgrade Alerts to 0.6.0.
I was trying to debug an issue reported on https://issues.jboss.org/browse/HWKALERTS-98 and I've noticed about this client.

This PR should go on master just when the release is done.

I will try to review the HWKALERTS-98 locally to check if it is an issue with the test environment or if there is some issue inside the alerts component.
