### PR TITLE
[HAWKULAR-1126] New client builder, headers not static

### DIFF
--- a/src/main/java/org/hawkular/client/alert/AlertsClientImpl.java
+++ b/src/main/java/org/hawkular/client/alert/AlertsClientImpl.java
@@ -16,7 +16,7 @@
  */
 package org.hawkular.client.alert;
 
-import java.net.URI;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.hawkular.client.alert.clients.ActionsClient;
 import org.hawkular.client.alert.clients.AlertClient;
@@ -34,9 +34,7 @@ import org.hawkular.client.alert.clients.ImportClient;
 import org.hawkular.client.alert.clients.PluginsClient;
 import org.hawkular.client.alert.clients.StatusClient;
 import org.hawkular.client.alert.clients.TriggersClient;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import org.hawkular.client.core.ClientInfo;
 
 public class AlertsClientImpl implements AlertsClient {
 
@@ -49,68 +47,55 @@ public class AlertsClientImpl implements AlertsClient {
     private final StatusClient status;
     private final TriggersClient triggers;
 
-    public AlertsClientImpl(URI endpointUri) throws Exception {
-        this(endpointUri, null, null);
-    }
-
-    public AlertsClientImpl(URI endpointUri, String username, String password) {
-        checkArgument(endpointUri != null, "EndpointUri is null");
-
-        alert = new DefaultAlertClient(endpointUri, username, password);
-        actions = new DefaultActionsClient(endpointUri, username, password);
-        events = new DefaultEventsClient(endpointUri, username, password);
-        export = new DefaultExportClient(endpointUri, username, password);
-        imports = new DefaultImportClient(endpointUri, username, password);
-        plugins = new DefaultPluginsClient(endpointUri, username, password);
-        status = new DefaultStatusClient(endpointUri, username, password);
-        triggers = new DefaultTriggersClient(endpointUri, username, password);
+    public AlertsClientImpl(ClientInfo clientInfo) {
+        checkNotNull(clientInfo);
+        alert = new DefaultAlertClient(clientInfo);
+        actions = new DefaultActionsClient(clientInfo);
+        events = new DefaultEventsClient(clientInfo);
+        export = new DefaultExportClient(clientInfo);
+        imports = new DefaultImportClient(clientInfo);
+        plugins = new DefaultPluginsClient(clientInfo);
+        status = new DefaultStatusClient(clientInfo);
+        triggers = new DefaultTriggersClient(clientInfo);
     }
 
     @Override
     public AlertClient alert() {
-        checkNotNull(alert != null, "AlertClient is null");
         return alert;
     }
 
     @Override
     public ActionsClient actions() {
-        checkNotNull(actions != null, "ActionsClient is null");
         return actions;
     }
 
     @Override
     public EventsClient events() {
-        checkNotNull(events != null, "EventsClient is null");
         return events;
     }
 
     @Override
     public ExportClient export() {
-        checkNotNull(export != null, "ExportClient is null");
         return export;
     }
 
     @Override
     public ImportClient imports() {
-        checkNotNull(imports != null, "ImportClient is null");
         return imports;
     }
 
     @Override
     public PluginsClient plugins() {
-        checkNotNull(plugins != null, "PluginsClient is null");
         return plugins;
     }
 
     @Override
     public StatusClient status() {
-        checkNotNull(status != null, "StatusClient is null");
         return status;
     }
 
     @Override
     public TriggersClient triggers() {
-        checkNotNull(triggers != null, "TriggersClient is null");
         return triggers;
     }
 }

--- a/src/main/java/org/hawkular/client/alert/clients/DefaultActionsClient.java
+++ b/src/main/java/org/hawkular/client/alert/clients/DefaultActionsClient.java
@@ -16,7 +16,6 @@
  */
 package org.hawkular.client.alert.clients;
 
-import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
@@ -26,6 +25,7 @@ import org.hawkular.alerts.api.model.action.Action;
 import org.hawkular.alerts.api.model.action.ActionDefinition;
 import org.hawkular.client.alert.jaxrs.handlers.ActionsHandler;
 import org.hawkular.client.core.BaseClient;
+import org.hawkular.client.core.ClientInfo;
 import org.hawkular.client.core.ClientResponse;
 import org.hawkular.client.core.DefaultClientResponse;
 import org.hawkular.client.core.jaxrs.Empty;
@@ -36,12 +36,8 @@ import com.fasterxml.jackson.databind.JavaType;
 
 public class DefaultActionsClient extends BaseClient<ActionsHandler> implements ActionsClient {
 
-    public DefaultActionsClient(URI endpointUri) {
-        this(endpointUri, null, null);
-    }
-
-    public DefaultActionsClient(URI endpointUri, String username, String password) {
-        super(endpointUri, username, password, new RestFactory<ActionsHandler>(ActionsHandler.class));
+    public DefaultActionsClient(ClientInfo clientInfo) {
+        super(clientInfo, new RestFactory<>(ActionsHandler.class));
     }
 
     @Override
@@ -52,7 +48,7 @@ public class DefaultActionsClient extends BaseClient<ActionsHandler> implements 
             serverResponse = restApi().findActions();
             JavaType javaType = mapResolver().get(Map.class, String.class, List.class, String.class);
 
-            return new DefaultClientResponse<Map<String, List<String>>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -68,7 +64,7 @@ public class DefaultActionsClient extends BaseClient<ActionsHandler> implements 
             serverResponse = restApi().createAction(definition);
             JavaType javaType = simpleResolver().get(ActionDefinition.class);
 
-            return new DefaultClientResponse<ActionDefinition>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -84,7 +80,7 @@ public class DefaultActionsClient extends BaseClient<ActionsHandler> implements 
             serverResponse = restApi().updateAction(definition);
             JavaType javaType = simpleResolver().get(ActionDefinition.class);
 
-            return new DefaultClientResponse<ActionDefinition>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -101,7 +97,7 @@ public class DefaultActionsClient extends BaseClient<ActionsHandler> implements 
             serverResponse = restApi().getActionHistory(startTime, endTime, actionPlugins, actionIds, alertIds, results, thin);
             JavaType javaType = collectionResolver().get(List.class, Action.class);
 
-            return new DefaultClientResponse<List<Action>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -118,7 +114,7 @@ public class DefaultActionsClient extends BaseClient<ActionsHandler> implements 
             serverResponse = restApi().deleteActionHistory(startTime, endTime, actionPlugins, actionIds, alertIds, results);
             JavaType javaType = simpleResolver().get(Integer.class);
 
-            return new DefaultClientResponse<Integer>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -134,7 +130,7 @@ public class DefaultActionsClient extends BaseClient<ActionsHandler> implements 
             serverResponse = restApi().findActionsByPlugin(actionPlugin);
             JavaType javaType = collectionResolver().get(List.class, String.class);
 
-            return new DefaultClientResponse<List<String>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -150,7 +146,7 @@ public class DefaultActionsClient extends BaseClient<ActionsHandler> implements 
             serverResponse = restApi().deleteAction(actionPlugin, actionId);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -166,7 +162,7 @@ public class DefaultActionsClient extends BaseClient<ActionsHandler> implements 
             serverResponse = restApi().getAction(actionPlugin, actionId);
             JavaType javaType = simpleResolver().get(ActionDefinition.class);
 
-            return new DefaultClientResponse<ActionDefinition>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();

--- a/src/main/java/org/hawkular/client/alert/clients/DefaultAlertClient.java
+++ b/src/main/java/org/hawkular/client/alert/clients/DefaultAlertClient.java
@@ -16,7 +16,6 @@
  */
 package org.hawkular.client.alert.clients;
 
-import java.net.URI;
 import java.util.List;
 
 import javax.ws.rs.core.Response;
@@ -25,6 +24,7 @@ import org.hawkular.alerts.api.model.data.Data;
 import org.hawkular.alerts.api.model.event.Alert;
 import org.hawkular.client.alert.jaxrs.handlers.AlertHandler;
 import org.hawkular.client.core.BaseClient;
+import org.hawkular.client.core.ClientInfo;
 import org.hawkular.client.core.ClientResponse;
 import org.hawkular.client.core.DefaultClientResponse;
 import org.hawkular.client.core.jaxrs.Empty;
@@ -35,12 +35,8 @@ import com.fasterxml.jackson.databind.JavaType;
 
 public class DefaultAlertClient extends BaseClient<AlertHandler> implements AlertClient {
 
-    public DefaultAlertClient(URI endpointUri) {
-        this(endpointUri, null, null);
-    }
-
-    public DefaultAlertClient(URI endpointUri, String username, String password) {
-        super(endpointUri, username, password, new RestFactory<AlertHandler>(AlertHandler.class));
+    public DefaultAlertClient(ClientInfo clientInfo) {
+        super(clientInfo, new RestFactory<>(AlertHandler.class));
     }
 
     @Override
@@ -52,7 +48,7 @@ public class DefaultAlertClient extends BaseClient<AlertHandler> implements Aler
             serverResponse = restApi().findAlerts(startTime, endTime, alertIds, triggerIds, statuses, severities, tags, thin);
             JavaType javaType = collectionResolver().get(List.class, Alert.class);
 
-            return new DefaultClientResponse<List<Alert>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -68,7 +64,7 @@ public class DefaultAlertClient extends BaseClient<AlertHandler> implements Aler
             serverResponse = restApi().ackAlerts(alertIds, ackBy, ackNotes);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -84,7 +80,7 @@ public class DefaultAlertClient extends BaseClient<AlertHandler> implements Aler
             serverResponse = restApi().ackAlert(alertId, ackBy, ackNotes);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -100,7 +96,7 @@ public class DefaultAlertClient extends BaseClient<AlertHandler> implements Aler
             serverResponse = restApi().getAlert(alertId, thin);
             JavaType javaType = simpleResolver().get(Alert.class);
 
-            return new DefaultClientResponse<Alert>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -116,7 +112,7 @@ public class DefaultAlertClient extends BaseClient<AlertHandler> implements Aler
             serverResponse = restApi().sendData(datums);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -133,7 +129,7 @@ public class DefaultAlertClient extends BaseClient<AlertHandler> implements Aler
             serverResponse = restApi().deleteAlerts(startTime, endTime, alertIds, triggerIds, statuses, severities, tags);
             JavaType javaType = simpleResolver().get(Integer.class);
 
-            return new DefaultClientResponse<Integer>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -149,7 +145,7 @@ public class DefaultAlertClient extends BaseClient<AlertHandler> implements Aler
             serverResponse = restApi().addNoteToAlert(alertId, user, text);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -165,7 +161,7 @@ public class DefaultAlertClient extends BaseClient<AlertHandler> implements Aler
             serverResponse = restApi().resolveAlerts(alertIds, resolvedBy, resolvedNotes);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -181,7 +177,7 @@ public class DefaultAlertClient extends BaseClient<AlertHandler> implements Aler
             serverResponse = restApi().resolveAlert(alertId, resolvedBy, resolvedNotes);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -197,7 +193,7 @@ public class DefaultAlertClient extends BaseClient<AlertHandler> implements Aler
             serverResponse = restApi().deleteTags(alertIds, tagNames);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -213,7 +209,7 @@ public class DefaultAlertClient extends BaseClient<AlertHandler> implements Aler
             serverResponse = restApi().addTag(alertIds, tagNames);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -229,7 +225,7 @@ public class DefaultAlertClient extends BaseClient<AlertHandler> implements Aler
             serverResponse = restApi().deleteAlert(alertId);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();

--- a/src/main/java/org/hawkular/client/alert/clients/DefaultEventsClient.java
+++ b/src/main/java/org/hawkular/client/alert/clients/DefaultEventsClient.java
@@ -16,7 +16,6 @@
  */
 package org.hawkular.client.alert.clients;
 
-import java.net.URI;
 import java.util.List;
 
 import javax.ws.rs.core.Response;
@@ -24,6 +23,7 @@ import javax.ws.rs.core.Response;
 import org.hawkular.alerts.api.model.event.Event;
 import org.hawkular.client.alert.jaxrs.handlers.EventsHandler;
 import org.hawkular.client.core.BaseClient;
+import org.hawkular.client.core.ClientInfo;
 import org.hawkular.client.core.ClientResponse;
 import org.hawkular.client.core.DefaultClientResponse;
 import org.hawkular.client.core.jaxrs.Empty;
@@ -34,12 +34,8 @@ import com.fasterxml.jackson.databind.JavaType;
 
 public class DefaultEventsClient extends BaseClient<EventsHandler> implements EventsClient {
 
-    public DefaultEventsClient(URI endpointUri) {
-        this(endpointUri, null, null);
-    }
-
-    public DefaultEventsClient(URI endpointUri, String username, String password) {
-        super(endpointUri, username, password, new RestFactory<EventsHandler>(EventsHandler.class));
+    public DefaultEventsClient(ClientInfo clientInfo) {
+        super(clientInfo, new RestFactory<>(EventsHandler.class));
     }
 
     @Override
@@ -51,7 +47,7 @@ public class DefaultEventsClient extends BaseClient<EventsHandler> implements Ev
             serverResponse = restApi().findEvents(startTime, endTime, eventIds, triggerIds, categories, tags, thin);
             JavaType javaType = collectionResolver().get(List.class, Event.class);
 
-            return new DefaultClientResponse<List<Event>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -67,7 +63,7 @@ public class DefaultEventsClient extends BaseClient<EventsHandler> implements Ev
             serverResponse = restApi().createEvent(event);
             JavaType javaType = simpleResolver().get(Event.class);
 
-            return new DefaultClientResponse<Event>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -84,7 +80,7 @@ public class DefaultEventsClient extends BaseClient<EventsHandler> implements Ev
             serverResponse = restApi().deleteEvents(startTime, endTime, eventIds, triggerIds, categories, tags);
             JavaType javaType = simpleResolver().get(Integer.class);
 
-            return new DefaultClientResponse<Integer>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -100,7 +96,7 @@ public class DefaultEventsClient extends BaseClient<EventsHandler> implements Ev
             serverResponse = restApi().getEvent(eventId, thin);
             JavaType javaType = simpleResolver().get(Event.class);
 
-            return new DefaultClientResponse<Event>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -116,7 +112,7 @@ public class DefaultEventsClient extends BaseClient<EventsHandler> implements Ev
             serverResponse = restApi().deleteTags(eventIds, tagNames);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -132,7 +128,7 @@ public class DefaultEventsClient extends BaseClient<EventsHandler> implements Ev
             serverResponse = restApi().createTags(eventIds, tagNames);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -148,7 +144,7 @@ public class DefaultEventsClient extends BaseClient<EventsHandler> implements Ev
             serverResponse = restApi().deleteEvent(eventId);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();

--- a/src/main/java/org/hawkular/client/alert/clients/DefaultExportClient.java
+++ b/src/main/java/org/hawkular/client/alert/clients/DefaultExportClient.java
@@ -16,13 +16,12 @@
  */
 package org.hawkular.client.alert.clients;
 
-import java.net.URI;
-
 import javax.ws.rs.core.Response;
 
 import org.hawkular.alerts.api.model.export.Definitions;
 import org.hawkular.client.alert.jaxrs.handlers.ExportHandler;
 import org.hawkular.client.core.BaseClient;
+import org.hawkular.client.core.ClientInfo;
 import org.hawkular.client.core.ClientResponse;
 import org.hawkular.client.core.DefaultClientResponse;
 import org.hawkular.client.core.jaxrs.ResponseCodes;
@@ -32,12 +31,8 @@ import com.fasterxml.jackson.databind.JavaType;
 
 public class DefaultExportClient extends BaseClient<ExportHandler> implements ExportClient {
 
-    public DefaultExportClient(URI endpointUri) {
-        this(endpointUri, null, null);
-    }
-
-    public DefaultExportClient(URI endpointUri, String username, String password) {
-        super(endpointUri, username, password, new RestFactory<ExportHandler>(ExportHandler.class));
+    public DefaultExportClient(ClientInfo clientInfo) {
+        super(clientInfo, new RestFactory<>(ExportHandler.class));
     }
 
     public ClientResponse<Definitions> export() {
@@ -47,7 +42,7 @@ public class DefaultExportClient extends BaseClient<ExportHandler> implements Ex
             serverResponse = restApi().export();
             JavaType javaType = simpleResolver().get(Definitions.class);
 
-            return new DefaultClientResponse<Definitions>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();

--- a/src/main/java/org/hawkular/client/alert/clients/DefaultImportClient.java
+++ b/src/main/java/org/hawkular/client/alert/clients/DefaultImportClient.java
@@ -16,13 +16,12 @@
  */
 package org.hawkular.client.alert.clients;
 
-import java.net.URI;
-
 import javax.ws.rs.core.Response;
 
 import org.hawkular.alerts.api.model.export.Definitions;
 import org.hawkular.client.alert.jaxrs.handlers.ImportHandler;
 import org.hawkular.client.core.BaseClient;
+import org.hawkular.client.core.ClientInfo;
 import org.hawkular.client.core.ClientResponse;
 import org.hawkular.client.core.DefaultClientResponse;
 import org.hawkular.client.core.jaxrs.ResponseCodes;
@@ -32,12 +31,8 @@ import com.fasterxml.jackson.databind.JavaType;
 
 public class DefaultImportClient extends BaseClient<ImportHandler> implements ImportClient {
 
-    public DefaultImportClient(URI endpointUri) {
-        this(endpointUri, null, null);
-    }
-
-    public DefaultImportClient(URI endpointUri, String username, String password) {
-        super(endpointUri, username, password, new RestFactory<ImportHandler>(ImportHandler.class));
+    public DefaultImportClient(ClientInfo clientInfo) {
+        super(clientInfo, new RestFactory<>(ImportHandler.class));
     }
 
     public ClientResponse<Definitions> importDefinitions(final String strategy, final Definitions definitions) {
@@ -47,7 +42,7 @@ public class DefaultImportClient extends BaseClient<ImportHandler> implements Im
             serverResponse = restApi().importDefinitions(strategy, definitions);
             JavaType javaType = simpleResolver().get(Definitions.class);
 
-            return new DefaultClientResponse<Definitions>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();

--- a/src/main/java/org/hawkular/client/alert/clients/DefaultPluginsClient.java
+++ b/src/main/java/org/hawkular/client/alert/clients/DefaultPluginsClient.java
@@ -16,13 +16,13 @@
  */
 package org.hawkular.client.alert.clients;
 
-import java.net.URI;
 import java.util.List;
 
 import javax.ws.rs.core.Response;
 
 import org.hawkular.client.alert.jaxrs.handlers.PluginsHandler;
 import org.hawkular.client.core.BaseClient;
+import org.hawkular.client.core.ClientInfo;
 import org.hawkular.client.core.ClientResponse;
 import org.hawkular.client.core.DefaultClientResponse;
 import org.hawkular.client.core.jaxrs.ResponseCodes;
@@ -32,12 +32,8 @@ import com.fasterxml.jackson.databind.JavaType;
 
 public class DefaultPluginsClient extends BaseClient<PluginsHandler> implements PluginsClient {
 
-    public DefaultPluginsClient(URI endpointUri) {
-        this(endpointUri, null, null);
-    }
-
-    public DefaultPluginsClient(URI endpointUri, String username, String password) {
-        super(endpointUri, username, password, new RestFactory<PluginsHandler>(PluginsHandler.class));
+    public DefaultPluginsClient(ClientInfo clientInfo) {
+        super(clientInfo, new RestFactory<>(PluginsHandler.class));
     }
 
     @Override
@@ -48,7 +44,7 @@ public class DefaultPluginsClient extends BaseClient<PluginsHandler> implements 
             serverResponse = restApi().findActionPlugins();
             JavaType javaType = collectionResolver().get(List.class, String.class);
 
-            return new DefaultClientResponse<List<String>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -64,7 +60,7 @@ public class DefaultPluginsClient extends BaseClient<PluginsHandler> implements 
             serverResponse = restApi().getActionPlugin(actionPlugin);
             JavaType javaType = collectionResolver().get(List.class, String.class);
 
-            return new DefaultClientResponse<List<String>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();

--- a/src/main/java/org/hawkular/client/alert/clients/DefaultStatusClient.java
+++ b/src/main/java/org/hawkular/client/alert/clients/DefaultStatusClient.java
@@ -16,13 +16,13 @@
  */
 package org.hawkular.client.alert.clients;
 
-import java.net.URI;
 import java.util.Map;
 
 import javax.ws.rs.core.Response;
 
 import org.hawkular.client.alert.jaxrs.handlers.StatusHandler;
 import org.hawkular.client.core.BaseClient;
+import org.hawkular.client.core.ClientInfo;
 import org.hawkular.client.core.ClientResponse;
 import org.hawkular.client.core.DefaultClientResponse;
 import org.hawkular.client.core.jaxrs.ResponseCodes;
@@ -32,12 +32,8 @@ import com.fasterxml.jackson.databind.JavaType;
 
 public class DefaultStatusClient extends BaseClient<StatusHandler> implements StatusClient {
 
-    public DefaultStatusClient(URI endpointUri) {
-        this(endpointUri, null, null);
-    }
-
-    public DefaultStatusClient(URI endpointUri, String username, String password) {
-        super(endpointUri, username, password, new RestFactory<StatusHandler>(StatusHandler.class));
+    public DefaultStatusClient(ClientInfo clientInfo) {
+        super(clientInfo, new RestFactory<>(StatusHandler.class));
     }
 
     @Override
@@ -48,7 +44,7 @@ public class DefaultStatusClient extends BaseClient<StatusHandler> implements St
             serverResponse = restApi().status();
             JavaType javaType = mapResolver().get(Map.class, String.class, String.class);
 
-            return new DefaultClientResponse<Map<String, String>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();

--- a/src/main/java/org/hawkular/client/alert/clients/DefaultTriggersClient.java
+++ b/src/main/java/org/hawkular/client/alert/clients/DefaultTriggersClient.java
@@ -16,7 +16,6 @@
  */
 package org.hawkular.client.alert.clients;
 
-import java.net.URI;
 import java.util.List;
 
 import javax.ws.rs.core.Response;
@@ -36,6 +35,7 @@ import org.hawkular.alerts.api.model.trigger.Mode;
 import org.hawkular.alerts.api.model.trigger.Trigger;
 import org.hawkular.client.alert.jaxrs.handlers.TriggersHandler;
 import org.hawkular.client.core.BaseClient;
+import org.hawkular.client.core.ClientInfo;
 import org.hawkular.client.core.ClientResponse;
 import org.hawkular.client.core.DefaultClientResponse;
 import org.hawkular.client.core.jaxrs.Empty;
@@ -46,12 +46,8 @@ import com.fasterxml.jackson.databind.JavaType;
 
 public class DefaultTriggersClient extends BaseClient<TriggersHandler> implements TriggersClient {
 
-    public DefaultTriggersClient(URI endpointUri) {
-        this(endpointUri, null, null);
-    }
-
-    public DefaultTriggersClient(URI endpointUri, String username, String password) {
-        super(endpointUri, username, password, new RestFactory<TriggersHandler>(TriggersHandler.class));
+    public DefaultTriggersClient(ClientInfo clientInfo) {
+        super(clientInfo, new RestFactory<>(TriggersHandler.class));
     }
 
     @Override
@@ -62,7 +58,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().findTriggers(triggerIds, tags, thin);
             JavaType javaType = collectionResolver().get(List.class, Trigger.class);
 
-            return new DefaultClientResponse<List<Trigger>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -78,7 +74,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().createTrigger(trigger);
             JavaType javaType = simpleResolver().get(Trigger.class);
 
-            return new DefaultClientResponse<Trigger>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -94,7 +90,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().createGroupTrigger(groupTrigger);
             JavaType javaType = simpleResolver().get(Trigger.class);
 
-            return new DefaultClientResponse<Trigger>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -110,7 +106,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().createGroupMember(groupMember);
             JavaType javaType = simpleResolver().get(Trigger.class);
 
-            return new DefaultClientResponse<Trigger>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -126,7 +122,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().orphanMemberTrigger(memberId);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -142,7 +138,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().unorphanMemberTrigger(memberId, unorphanMemberInfo);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -158,7 +154,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().deleteGroupTrigger(groupId, keepNonOrphans, keepOrphans);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -174,7 +170,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().updateGroupTrigger(groupId, groupTrigger);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -190,7 +186,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().setGroupConditions(groupId, triggerMode, groupConditionsInfo);
             JavaType javaType = collectionResolver().get(List.class, Condition.class);
 
-            return new DefaultClientResponse<List<Condition>>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -206,7 +202,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().createGroupDampening(groupId, dampening);
             JavaType javaType = simpleResolver().get(Dampening.class);
 
-            return new DefaultClientResponse<Dampening>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -222,7 +218,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().deleteGroupDampening(groupId, dampeningId);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -238,7 +234,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().updateGroupDampening(groupId, dampeningId, dampening);
             JavaType javaType = simpleResolver().get(Dampening.class);
 
-            return new DefaultClientResponse<Dampening>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -254,7 +250,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().findGroupMembers(groupId, includeOrphans);
             JavaType javaType = collectionResolver().get(List.class, Trigger.class);
 
-            return new DefaultClientResponse<List<Trigger>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -270,7 +266,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().createFullTrigger(fullTrigger);
             JavaType javaType = simpleResolver().get(FullTrigger.class);
 
-            return new DefaultClientResponse<FullTrigger>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -286,7 +282,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().getFullTriggerById(triggerId);
             JavaType javaType = simpleResolver().get(FullTrigger.class);
 
-            return new DefaultClientResponse<FullTrigger>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -302,7 +298,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().deleteTrigger(triggerId);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -318,7 +314,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().getTrigger(triggerId);
             JavaType javaType = simpleResolver().get(Trigger.class);
 
-            return new DefaultClientResponse<Trigger>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -334,7 +330,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().updateTrigger(triggerId, trigger);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -350,7 +346,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().getTriggerConditions(triggerId);
             JavaType javaType = collectionResolver().get(List.class, Condition.class);
 
-            return new DefaultClientResponse<List<Condition>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -367,7 +363,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().setAvailabilityCondition(triggerId, triggerMode, conditions);
             JavaType javaType = collectionResolver().get(List.class, AvailabilityCondition.class);
 
-            return new DefaultClientResponse<List<AvailabilityCondition>>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -384,7 +380,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().setCompareCondition(triggerId, triggerMode, conditions);
             JavaType javaType = collectionResolver().get(List.class, CompareCondition.class);
 
-            return new DefaultClientResponse<List<CompareCondition>>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -401,7 +397,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().setStringCondition(triggerId, triggerMode, conditions);
             JavaType javaType = collectionResolver().get(List.class, CompareCondition.class);
 
-            return new DefaultClientResponse<List<StringCondition>>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -418,7 +414,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().setThresholdCondition(triggerId, triggerMode, conditions);
             JavaType javaType = collectionResolver().get(List.class, ThresholdCondition.class);
 
-            return new DefaultClientResponse<List<ThresholdCondition>>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -435,7 +431,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().setThresholdRangeCondition(triggerId, triggerMode, conditions);
             JavaType javaType = collectionResolver().get(List.class, ThresholdRangeCondition.class);
 
-            return new DefaultClientResponse<List<ThresholdRangeCondition>>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -451,7 +447,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().getTriggerDampenings(triggerId);
             JavaType javaType = collectionResolver().get(List.class, Dampening.class);
 
-            return new DefaultClientResponse<List<Dampening>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -467,7 +463,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().createDampening(triggerId, dampening);
             JavaType javaType = simpleResolver().get(Dampening.class);
 
-            return new DefaultClientResponse<Dampening>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -483,7 +479,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().getTriggerModeDampenings(triggerId, triggerMode);
             JavaType javaType = collectionResolver().get(List.class, Dampening.class);
 
-            return new DefaultClientResponse<List<Dampening>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -499,7 +495,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().deleteDampening(triggerId, dampeningId);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -515,7 +511,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().getDampening(triggerId, dampeningId);
             JavaType javaType = simpleResolver().get(Dampening.class);
 
-            return new DefaultClientResponse<Dampening>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -531,7 +527,7 @@ public class DefaultTriggersClient extends BaseClient<TriggersHandler> implement
             serverResponse = restApi().updateDampening(triggerId, dampeningId, dampening);
             JavaType javaType = simpleResolver().get(Dampening.class);
 
-            return new DefaultClientResponse<Dampening>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();

--- a/src/main/java/org/hawkular/client/core/BaseClient.java
+++ b/src/main/java/org/hawkular/client/core/BaseClient.java
@@ -16,16 +16,12 @@
  */
 package org.hawkular.client.core;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
-import java.net.URI;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.hawkular.client.core.jaxrs.RestFactory;
 import org.hawkular.client.core.typeresolvers.CollectionJavaTypeResolver;
 import org.hawkular.client.core.typeresolvers.MapJavaTypeResolver;
 import org.hawkular.client.core.typeresolvers.SimpleJavaTypeResolver;
-
-import com.google.common.base.Strings;
 
 public abstract class BaseClient<T> {
 
@@ -34,14 +30,9 @@ public abstract class BaseClient<T> {
     private CollectionJavaTypeResolver collectionJavaTypeResolver = new CollectionJavaTypeResolver();
     private MapJavaTypeResolver mapJavaTypeResolver = new MapJavaTypeResolver();
 
-    public BaseClient(URI endpointUri, String username, String password, RestFactory<T> restFactory) {
-        checkArgument(endpointUri != null, "EndpointUri is null");
-
-        if (Strings.isNullOrEmpty(username) || Strings.isNullOrEmpty(password)) {
-            restAPI = (T)restFactory.createAPI(endpointUri);
-        } else {
-            restAPI = (T)restFactory.createAPI(endpointUri, username, password);
-        }
+    public BaseClient(ClientInfo clientInfo, RestFactory<T> restFactory) {
+        checkNotNull(clientInfo);
+        restAPI = restFactory.createAPI(clientInfo);
     }
 
     public T restApi() {

--- a/src/main/java/org/hawkular/client/core/ClientInfo.java
+++ b/src/main/java/org/hawkular/client/core/ClientInfo.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.client.core;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+
+import com.google.common.collect.ImmutableMap;
+
+public final class ClientInfo {
+
+    private final URI endpointUri;
+    private final Optional<String> username;
+    private final Optional<String> password;
+    private final Map<String, Object> headers;
+
+    public ClientInfo(URI endpointUri, Optional<String> username, Optional<String> password, Map<String, Object>
+            headers) {
+        this.endpointUri = checkNotNull(endpointUri);
+        this.username = checkNotNull(username);
+        this.password = checkNotNull(password);
+        this.headers = ImmutableMap.copyOf(checkNotNull(headers));
+    }
+
+    public URI getEndpointUri() {
+        return endpointUri;
+    }
+
+    public Optional<String> getUsername() {
+        return username;
+    }
+
+    public Optional<String> getPassword() {
+        return password;
+    }
+
+    public Map<String, Object> getHeaders() {
+        return headers;
+    }
+
+    @Override public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ClientInfo that = (ClientInfo) o;
+
+        if (endpointUri != null ? !endpointUri.equals(that.endpointUri) : that.endpointUri != null) return false;
+        if (username != null ? !username.equals(that.username) : that.username != null) return false;
+        if (password != null ? !password.equals(that.password) : that.password != null) return false;
+        return headers != null ? headers.equals(that.headers) : that.headers == null;
+
+    }
+
+    @Override public int hashCode() {
+        int result = endpointUri != null ? endpointUri.hashCode() : 0;
+        result = 31 * result + (username != null ? username.hashCode() : 0);
+        result = 31 * result + (password != null ? password.hashCode() : 0);
+        result = 31 * result + (headers != null ? headers.hashCode() : 0);
+        return result;
+    }
+
+    @Override public String toString() {
+        return "ClientInfo{" +
+                "endpointUri=" + endpointUri +
+                ", username=" + username +
+                ", password=" + password +
+                ", headers=" + headers +
+                '}';
+    }
+}

--- a/src/main/java/org/hawkular/client/core/HawkularClientBuilder.java
+++ b/src/main/java/org/hawkular/client/core/HawkularClientBuilder.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.client.core;
+
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import com.google.common.base.Throwables;
+
+public class HawkularClientBuilder {
+
+    private URI uri;
+    private Optional<String> username = Optional.empty();
+    private Optional<String> password = Optional.empty();
+    private Map<String, Object> headers = new HashMap<>();
+
+    public HawkularClientBuilder(String tenant) {
+        try {
+            uri = new URI("http://127.0.0.1:8080");
+        } catch (URISyntaxException e) {
+            Throwables.propagate(e);
+        }
+        headers.put(HawkularClient.KEY_HEADER_TENANT, tenant);
+    }
+
+    public HawkularClientBuilder uri(String uri) throws URISyntaxException {
+        return uri(new URI(uri));
+    }
+
+    public HawkularClientBuilder uri(URI uri) {
+        this.uri = uri;
+        return this;
+    }
+
+    public HawkularClientBuilder basicAuthentication(String username, String password) {
+        this.username = Optional.ofNullable(username);
+        this.password = Optional.ofNullable(password);
+        return this;
+    }
+
+    public HawkularClientBuilder basicAuthentication(Optional<String> username, Optional<String> password) {
+        this.username = username;
+        this.password = password;
+        return this;
+    }
+
+    public HawkularClientBuilder tokenAuthentication(String token) {
+        headers.put(HawkularClient.KEY_HEADER_AUTHORIZATION, "Bearer " + token);
+        return this;
+    }
+
+    public HawkularClientBuilder addHeader(String key, Object value) {
+        headers.put(key, value);
+        return this;
+    }
+
+    public HawkularClient build() {
+        ClientInfo clientInfo = new ClientInfo(uri, username, password, headers);
+        return new HawkularClient(clientInfo);
+    }
+}

--- a/src/main/java/org/hawkular/client/core/jaxrs/RequestHeadersFilter.java
+++ b/src/main/java/org/hawkular/client/core/jaxrs/RequestHeadersFilter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.client.core.jaxrs;
+
+import java.io.IOException;
+import java.util.Map;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+
+public class RequestHeadersFilter implements ClientRequestFilter {
+
+    private final MultivaluedMap<String, Object> headers;
+
+    public RequestHeadersFilter(Map<String, Object> headers) {
+        this.headers = new MultivaluedHashMap<>(headers);
+    }
+
+    @Override
+    public void filter(ClientRequestContext requestContext) throws IOException {
+        requestContext.getHeaders().putAll(headers);
+    }
+}

--- a/src/main/java/org/hawkular/client/core/jaxrs/RestRequestFilter.java
+++ b/src/main/java/org/hawkular/client/core/jaxrs/RestRequestFilter.java
@@ -17,8 +17,6 @@
 package org.hawkular.client.core.jaxrs;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
@@ -36,13 +34,9 @@ public class RestRequestFilter implements ClientRequestFilter {
 
     private static final Logger _logger = LoggerFactory.getLogger(RestRequestFilter.class);
     private static ObjectMapper OBJECT_MAPPER = new ClientObjectMapper();
-    private static HashMap<String, Object> additionalHeaders = new HashMap<String, Object>();
 
     @Override
     public void filter(ClientRequestContext requestContext) throws IOException {
-        for (Map.Entry<String, Object> current : additionalHeaders.entrySet()) {
-            requestContext.getHeaders().add(current.getKey(), current.getValue());
-        }
         logRequests(requestContext);
     }
 
@@ -55,13 +49,4 @@ public class RestRequestFilter implements ClientRequestFilter {
                     .writeValueAsString(requestContext.getEntity()));
         }
     }
-
-    public static void updateHeader(String key, Object value) {
-        additionalHeaders.put(key, value);
-    }
-
-    public static void removeHeader(String key) {
-        additionalHeaders.remove(key);
-    }
-
 }

--- a/src/main/java/org/hawkular/client/inventory/InventoryClientImpl.java
+++ b/src/main/java/org/hawkular/client/inventory/InventoryClientImpl.java
@@ -16,7 +16,6 @@
  */
 package org.hawkular.client.inventory;
 
-import java.net.URI;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +23,7 @@ import java.util.Map;
 import javax.ws.rs.core.Response;
 
 import org.hawkular.client.core.BaseClient;
+import org.hawkular.client.core.ClientInfo;
 import org.hawkular.client.core.ClientResponse;
 import org.hawkular.client.core.ClientResponseOld;
 import org.hawkular.client.core.jaxrs.RestFactory;
@@ -50,13 +50,8 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
     private String tenantId = null;
     private static final long MINUTE = 1000 * 60;
 
-    public InventoryClientImpl(URI endpointUri, String username,
-            String password)  {
-        super(endpointUri, username, password, new RestFactory<InventoryRestApi>(InventoryRestApi.class));
-    }
-
-    public InventoryClientImpl(URI endpointUri)  {
-        this(endpointUri, null, null);
+    public InventoryClientImpl(ClientInfo clientInfo)  {
+        super(clientInfo, new RestFactory<>(InventoryRestApi.class));
     }
 
     public String getTenantId() {
@@ -68,21 +63,21 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
 
     @Override
     public ClientResponse<String> pingTime() {
-        return new ClientResponseOld<String>(String.class,
+        return new ClientResponseOld<>(String.class,
                 restApi().pingTime(),
                 RESPONSE_CODE.GET_SUCCESS.value());
     }
 
     @Override
     public ClientResponse<Endpoints> pingHello() {
-        return new ClientResponseOld<Endpoints>(Endpoints.class,
+        return new ClientResponseOld<>(Endpoints.class,
                 restApi().pingHello(),
                 RESPONSE_CODE.GET_SUCCESS.value());
     }
 
     @Override
     public ClientResponse<Tenant> getTenant() {
-        return new ClientResponseOld<Tenant>(Tenant.class, restApi().getTenant(), RESPONSE_CODE.GET_SUCCESS.value());
+        return new ClientResponseOld<>(Tenant.class, restApi().getTenant(), RESPONSE_CODE.GET_SUCCESS.value());
     }
 
     @Override
@@ -92,25 +87,25 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
 
     @Override
     public ClientResponse<String> updateTenant(Update updateTenant) {
-        return new ClientResponseOld<String>(String.class, restApi().getTenant(), RESPONSE_CODE.UPDATE_SUCCESS.value());
+        return new ClientResponseOld<>(String.class, restApi().getTenant(), RESPONSE_CODE.UPDATE_SUCCESS.value());
     }
 
     @Override
     public ClientResponse<String> deleteTenant() {
-        return new ClientResponseOld<String>(String.class, restApi().deleteTenant(), RESPONSE_CODE.DELETE_SUCCESS.value());
+        return new ClientResponseOld<>(String.class, restApi().deleteTenant(), RESPONSE_CODE.DELETE_SUCCESS.value());
     }
 
     //Enviroment
 
     @Override
     public ClientResponse<List<Environment>> getEnvironments() {
-        return new ClientResponseOld<List<Environment>>(Environment.class, restApi().getEnvironments(),
+        return new ClientResponseOld<>(Environment.class, restApi().getEnvironments(),
                 RESPONSE_CODE.GET_SUCCESS.value(), getTenantId(), true);
     }
 
     @Override
     public ClientResponse<Environment> getEnvironment(String environmentId) {
-        return new ClientResponseOld<Environment>(Environment.class, restApi().getEnvironment(environmentId),
+        return new ClientResponseOld<>(Environment.class, restApi().getEnvironment(environmentId),
                 RESPONSE_CODE.GET_SUCCESS.value(), getTenantId());
     }
 
@@ -121,7 +116,7 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
 
     @Override
     public ClientResponse<String> createEnvironment(Environment.Blueprint environmentBlueprint) {
-        return new ClientResponseOld<String>(String.class, restApi().createEnvironment(environmentBlueprint),
+        return new ClientResponseOld<>(String.class, restApi().createEnvironment(environmentBlueprint),
                 RESPONSE_CODE.CREATE_SUCCESS.value());
     }
 
@@ -143,7 +138,7 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
 
     @Override
     public ClientResponse<String> updateEnvironment(String environmentId, Environment.Update update) {
-        return new ClientResponseOld<String>(String.class, restApi().updateEnvironment(environmentId, update),
+        return new ClientResponseOld<>(String.class, restApi().updateEnvironment(environmentId, update),
                 RESPONSE_CODE.UPDATE_SUCCESS.value());
     }
 
@@ -159,7 +154,7 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
 
     @Override
     public ClientResponse<String> deleteEnvironment(String environmentId) {
-        return new ClientResponseOld<String>(String.class, restApi().deleteEnvironment(environmentId),
+        return new ClientResponseOld<>(String.class, restApi().deleteEnvironment(environmentId),
                 RESPONSE_CODE.DELETE_SUCCESS.value());
     }
 
@@ -172,13 +167,13 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
 
     @Override
     public ClientResponse<List<MetricType>> getMetricTypes() {
-        return new ClientResponseOld<List<MetricType>>(MetricType.class, restApi().getMetricTypes(),
+        return new ClientResponseOld<>(MetricType.class, restApi().getMetricTypes(),
                 RESPONSE_CODE.GET_SUCCESS.value(), getTenantId(), true);
     }
 
     @Override
     public ClientResponse<MetricType> getMetricType(String metricTypeId) {
-        return new ClientResponseOld<MetricType>(MetricType.class, this.restApi().getMetricType(metricTypeId),
+        return new ClientResponseOld<>(MetricType.class, this.restApi().getMetricType(metricTypeId),
                 RESPONSE_CODE.GET_SUCCESS.value(), getTenantId());
     }
 
@@ -189,7 +184,7 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
 
     @Override
     public ClientResponse<String> createMetricType(MetricType.Blueprint metricType) {
-        return new ClientResponseOld<String>(String.class, restApi().createMetricType(metricType),
+        return new ClientResponseOld<>(String.class, restApi().createMetricType(metricType),
                 RESPONSE_CODE.CREATE_SUCCESS.value());
     }
 
@@ -209,7 +204,7 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
     @Override
     public ClientResponse<String> updateMetricType(String metricTypeId,
             MetricType.Update metricUpdate) {
-        return new ClientResponseOld<String>(String.class, restApi().updateMetricType(metricTypeId, metricUpdate),
+        return new ClientResponseOld<>(String.class, restApi().updateMetricType(metricTypeId, metricUpdate),
                 RESPONSE_CODE.UPDATE_SUCCESS.value());
     }
 
@@ -221,7 +216,7 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
 
     @Override
     public ClientResponse<String> deleteMetricType(String metricTypeId) {
-        return new ClientResponseOld<String>(String.class, restApi().deleteMetricType(metricTypeId),
+        return new ClientResponseOld<>(String.class, restApi().deleteMetricType(metricTypeId),
                 RESPONSE_CODE.DELETE_SUCCESS.value());
     }
 
@@ -240,7 +235,7 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
         } else {
             response = restApi().createMetric(environmentId, feedId, metric);
         }
-        return new ClientResponseOld<String>(String.class, response, RESPONSE_CODE.CREATE_SUCCESS.value());
+        return new ClientResponseOld<>(String.class, response, RESPONSE_CODE.CREATE_SUCCESS.value());
     }
 
     @Override
@@ -263,10 +258,10 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
     @Override
     public ClientResponse<Metric> getMetric(String environmentId, String feedId, String metricId) {
         if (feedId == null) {
-            return new ClientResponseOld<Metric>(Metric.class, this.restApi().getMetric(environmentId, metricId),
+            return new ClientResponseOld<>(Metric.class, this.restApi().getMetric(environmentId, metricId),
                     RESPONSE_CODE.GET_SUCCESS.value(), getTenantId());
         } else {
-            return new ClientResponseOld<Metric>(Metric.class, this.restApi().getMetric(environmentId, feedId, metricId),
+            return new ClientResponseOld<>(Metric.class, this.restApi().getMetric(environmentId, feedId, metricId),
                     RESPONSE_CODE.GET_SUCCESS.value(), getTenantId());
         }
     }
@@ -278,14 +273,14 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
 
     @Override
     public ClientResponse<List<Metric>> getMetrics(String environmentId) {
-        return new ClientResponseOld<List<Metric>>(Metric.class, restApi().getMetrics(environmentId),
+        return new ClientResponseOld<>(Metric.class, restApi().getMetrics(environmentId),
                 RESPONSE_CODE.GET_SUCCESS.value(), getTenantId(), true);
 
     }
 
     @Override
     public ClientResponse<List<Metric>> getMetrics(String environmentId, String feedId) {
-        return new ClientResponseOld<List<Metric>>(Metric.class, restApi().getMetrics(environmentId, feedId),
+        return new ClientResponseOld<>(Metric.class, restApi().getMetrics(environmentId, feedId),
                 RESPONSE_CODE.GET_SUCCESS.value(), getTenantId(), true);
     }
 
@@ -298,7 +293,7 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
         } else {
             response = restApi().updateMetric(environmentId, feedId, metricId, metricUpdate);
         }
-        return new ClientResponseOld<String>(String.class, response, RESPONSE_CODE.UPDATE_SUCCESS.value());
+        return new ClientResponseOld<>(String.class, response, RESPONSE_CODE.UPDATE_SUCCESS.value());
     }
 
     @Override
@@ -321,7 +316,7 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
         } else {
             response = restApi().deleteMetric(environmentId, feedId, metricId);
         }
-        return new ClientResponseOld<String>(String.class, response, RESPONSE_CODE.DELETE_SUCCESS.value());
+        return new ClientResponseOld<>(String.class, response, RESPONSE_CODE.DELETE_SUCCESS.value());
     }
 
     @Override
@@ -338,13 +333,13 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
     //Get Resource Types
     @Override
     public ClientResponse<List<ResourceType>> getResourceTypes() {
-        return new ClientResponseOld<List<ResourceType>>(ResourceType.class, restApi().getResourceTypes(),
+        return new ClientResponseOld<>(ResourceType.class, restApi().getResourceTypes(),
                 RESPONSE_CODE.GET_SUCCESS.value(), getTenantId(), true);
     }
 
     @Override
     public ClientResponse<ResourceType> getResourceType(String resourceTypeId) {
-        return new ClientResponseOld<ResourceType>(ResourceType.class, restApi().getResourceType(resourceTypeId),
+        return new ClientResponseOld<>(ResourceType.class, restApi().getResourceType(resourceTypeId),
                 RESPONSE_CODE.GET_SUCCESS.value(), getTenantId());
     }
 
@@ -355,19 +350,19 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
 
     @Override
     public ClientResponse<List<MetricType>> getMetricTypes(String resourceTypeId) {
-        return new ClientResponseOld<List<MetricType>>(MetricType.class, restApi().getMetricTypes(),
+        return new ClientResponseOld<>(MetricType.class, restApi().getMetricTypes(),
                 RESPONSE_CODE.GET_SUCCESS.value(), getTenantId(), true);
     }
 
     @Override
     public ClientResponse<List<Resource>> getResources(String resourceTypeId) {
-        return new ClientResponseOld<List<Resource>>(Resource.class, restApi().getResources(resourceTypeId),
+        return new ClientResponseOld<>(Resource.class, restApi().getResources(resourceTypeId),
                 RESPONSE_CODE.GET_SUCCESS.value(), getTenantId(), true);
     }
 
     @Override
     public ClientResponse<String> createResourceType(ResourceType.Blueprint resourceType) {
-        return new ClientResponseOld<String>(String.class, restApi().createResourceType(resourceType),
+        return new ClientResponseOld<>(String.class, restApi().createResourceType(resourceType),
                 RESPONSE_CODE.CREATE_SUCCESS.value());
     }
 
@@ -383,7 +378,7 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
 
     @Override
     public ClientResponse<String> updateResourceType(String resourceTypeId, ResourceType.Update resourceTypeUpdate) {
-        return new ClientResponseOld<String>(String.class,
+        return new ClientResponseOld<>(String.class,
                 restApi().updateResourceType(resourceTypeId, resourceTypeUpdate),
                 RESPONSE_CODE.UPDATE_SUCCESS.value());
     }
@@ -395,7 +390,7 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
 
     @Override
     public ClientResponse<String> deleteResourceType(String resourceTypeId) {
-        return new ClientResponseOld<String>(String.class,
+        return new ClientResponseOld<>(String.class,
                 restApi().deleteResourceType(resourceTypeId),
                 RESPONSE_CODE.DELETE_SUCCESS.value());
     }
@@ -407,14 +402,14 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
 
     @Override
     public ClientResponse<String> addMetricType(String resourceTypeId, IdJSON metricTypeId) {
-        return new ClientResponseOld<String>(String.class,
+        return new ClientResponseOld<>(String.class,
                 restApi().addMetricType(resourceTypeId, metricTypeId),
                 RESPONSE_CODE.ADD_SUCCESS.value());
     }
 
     @Override
     public ClientResponse<String> removeMetricType(String resourceTypeId, String metricTypeId) {
-        return new ClientResponseOld<String>(String.class,
+        return new ClientResponseOld<>(String.class,
                 restApi().removeMetricType(resourceTypeId, metricTypeId),
                 RESPONSE_CODE.REMOVE_SUCCESS.value());
     }
@@ -428,7 +423,7 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
         } else {
             response = restApi().addResource(environmentId, feedId, resource);
         }
-        return new ClientResponseOld<String>(String.class, response, RESPONSE_CODE.ADD_SUCCESS.value());
+        return new ClientResponseOld<>(String.class, response, RESPONSE_CODE.ADD_SUCCESS.value());
     }
 
     @Override
@@ -449,7 +444,7 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
     @Override
     public ClientResponse<List<Resource>> getResourcesByType(String environmentId, String typeId, String typeVersion,
             boolean feedless) {
-        return new ClientResponseOld<List<Resource>>(Resource.class, restApi().getResourcesByType(environmentId, typeId,
+        return new ClientResponseOld<>(Resource.class, restApi().getResourcesByType(environmentId, typeId,
                 typeVersion, feedless), RESPONSE_CODE.GET_SUCCESS.value(), getTenantId(), true);
     }
 
@@ -461,7 +456,7 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
     @Override
     public ClientResponse<List<Resource>> getResourcesByType(String environmentId, String feedId, String typeId,
             String typeVersion) {
-        return new ClientResponseOld<List<Resource>>(Resource.class, restApi().getResourcesByType(environmentId, feedId,
+        return new ClientResponseOld<>(Resource.class, restApi().getResourcesByType(environmentId, feedId,
                 typeId, typeVersion), RESPONSE_CODE.GET_SUCCESS.value(), getTenantId(), true);
     }
 
@@ -473,7 +468,7 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
         } else {
             response = restApi().getResource(environmentId, feedId, resourceId);
         }
-        return new ClientResponseOld<Resource>(Resource.class, response, RESPONSE_CODE.GET_SUCCESS.value(), getTenantId());
+        return new ClientResponseOld<>(Resource.class, response, RESPONSE_CODE.GET_SUCCESS.value(), getTenantId());
 
     }
 
@@ -497,7 +492,7 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
         } else {
             response = restApi().updateResource(environmentId, feedId, resourceId, update);
         }
-        return new ClientResponseOld<String>(String.class, response, RESPONSE_CODE.UPDATE_SUCCESS.value());
+        return new ClientResponseOld<>(String.class, response, RESPONSE_CODE.UPDATE_SUCCESS.value());
     }
 
     @Override
@@ -520,7 +515,7 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
         } else {
             response = restApi().deleteResource(environmentId, feedId, resourceId);
         }
-        return new ClientResponseOld<String>(String.class, response, RESPONSE_CODE.DELETE_SUCCESS.value());
+        return new ClientResponseOld<>(String.class, response, RESPONSE_CODE.DELETE_SUCCESS.value());
     }
 
     @Override
@@ -543,7 +538,7 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
         } else {
             response = restApi().addMetricToResource(environmentId, feedId, resourceId, metricIds);
         }
-        return new ClientResponseOld<String>(String.class, response, RESPONSE_CODE.ADD_SUCCESS.value());
+        return new ClientResponseOld<>(String.class, response, RESPONSE_CODE.ADD_SUCCESS.value());
     }
 
     @Override
@@ -560,7 +555,7 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
         } else {
             response = restApi().listMetricsOfResource(environmentID, feedId, resourceId);
         }
-        return new ClientResponseOld<List<Metric>>(Metric.class, response, RESPONSE_CODE.GET_SUCCESS.value(),
+        return new ClientResponseOld<>(Metric.class, response, RESPONSE_CODE.GET_SUCCESS.value(),
                 getTenantId(), true);
     }
 
@@ -578,7 +573,7 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
         } else {
             response = this.restApi().getMetricOfResource(environmentId, feedId, resourceId, metricId);
         }
-        return new ClientResponseOld<Metric>(Metric.class, response, RESPONSE_CODE.GET_SUCCESS.value(), getTenantId());
+        return new ClientResponseOld<>(Metric.class, response, RESPONSE_CODE.GET_SUCCESS.value(), getTenantId());
     }
 
     @Override
@@ -589,7 +584,7 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
     //Feed
     @Override
     public ClientResponse<String> registerFeed(Feed.Blueprint feed) {
-        return new ClientResponseOld<String>(String.class, restApi().registerFeed(feed),
+        return new ClientResponseOld<>(String.class, restApi().registerFeed(feed),
                 RESPONSE_CODE.REGISTER_SUCCESS.value());
     }
 
@@ -600,13 +595,13 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
 
     @Override
     public ClientResponse<List<Feed>> getAllFeeds() {
-        return new ClientResponseOld<List<Feed>>(Feed.class, restApi().getAllFeeds(),
+        return new ClientResponseOld<>(Feed.class, restApi().getAllFeeds(),
                 RESPONSE_CODE.GET_SUCCESS.value(), getTenantId(), true);
     }
 
     @Override
     public ClientResponse<Feed> getFeed(String feedId) {
-        return new ClientResponseOld<Feed>(Feed.class, restApi().getFeed(feedId),
+        return new ClientResponseOld<>(Feed.class, restApi().getFeed(feedId),
                 RESPONSE_CODE.GET_SUCCESS.value(), getTenantId());
     }
 
@@ -617,7 +612,7 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
 
     @Override
     public ClientResponse<String> updateFeed(String feedId, Feed.Update update) {
-        return new ClientResponseOld<String>(String.class, restApi().updateFeed(feedId, update),
+        return new ClientResponseOld<>(String.class, restApi().updateFeed(feedId, update),
                 RESPONSE_CODE.UPDATE_SUCCESS.value());
     }
 
@@ -628,7 +623,7 @@ public class InventoryClientImpl extends BaseClient<InventoryRestApi>
 
     @Override
     public ClientResponse<String> deleteFeed(String feedId) {
-        return new ClientResponseOld<String>(String.class, restApi().deleteFeed(feedId),
+        return new ClientResponseOld<>(String.class, restApi().deleteFeed(feedId),
                 RESPONSE_CODE.DELETE_SUCCESS.value());
     }
 

--- a/src/main/java/org/hawkular/client/metrics/MetricsClientImpl.java
+++ b/src/main/java/org/hawkular/client/metrics/MetricsClientImpl.java
@@ -16,11 +16,9 @@
  */
 package org.hawkular.client.metrics;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.net.URI;
-
+import org.hawkular.client.core.ClientInfo;
 import org.hawkular.client.metrics.clients.AvailabilityClient;
 import org.hawkular.client.metrics.clients.CounterClient;
 import org.hawkular.client.metrics.clients.DefaultAvailabilityClient;
@@ -49,68 +47,55 @@ public class MetricsClientImpl implements MetricsClient {
     private final DefaultPingClient ping;
     private final DefaultStatusClient status;
 
-    public MetricsClientImpl(URI endpointUri) throws Exception {
-        this(endpointUri, null, null);
-    }
-
-    public MetricsClientImpl(URI endpointUri, String username, String password) {
-        checkArgument(endpointUri != null, "EndpointUri is null");
-
-        availability = new DefaultAvailabilityClient(endpointUri, username, password);
-        counter = new DefaultCounterClient(endpointUri, username, password);
-        gauge = new DefaultGaugeClient(endpointUri, username, password);
-        metric = new DefaultMetricClient(endpointUri, username, password);
-        string = new DefaultStringClient(endpointUri, username, password);
-        tenant = new DefaultTenantClient(endpointUri, username, password);
-        ping = new DefaultPingClient(endpointUri, username, password);
-        status = new DefaultStatusClient(endpointUri, username, password);
+    public MetricsClientImpl(ClientInfo clientInfo) {
+        checkNotNull(clientInfo);
+        availability = new DefaultAvailabilityClient(clientInfo);
+        counter = new DefaultCounterClient(clientInfo);
+        gauge = new DefaultGaugeClient(clientInfo);
+        metric = new DefaultMetricClient(clientInfo);
+        string = new DefaultStringClient(clientInfo);
+        tenant = new DefaultTenantClient(clientInfo);
+        ping = new DefaultPingClient(clientInfo);
+        status = new DefaultStatusClient(clientInfo);
     }
 
     @Override
     public AvailabilityClient availability() {
-        checkNotNull(availability != null, "AvailabilityClient is null");
         return availability;
     }
 
     @Override
     public CounterClient counter() {
-        checkNotNull(counter != null, "CounterClient is null");
         return counter;
     }
 
     @Override
     public GaugeClient gauge() {
-        checkNotNull(gauge != null, "GaugeClient is null");
         return gauge;
     }
 
     @Override
     public MetricClient metric() {
-        checkNotNull(metric != null, "MetricClient is null");
         return metric;
     }
 
     @Override
     public StringClient string() {
-        checkNotNull(string != null, "StringClient is null");
         return string;
     }
 
     @Override
     public TenantClient tenant() {
-        checkNotNull(tenant != null, "TenantClient is null");
         return tenant;
     }
 
     @Override
     public PingClient ping() {
-        checkNotNull(ping != null, "PingClient is null");
         return ping;
     }
 
     @Override
     public StatusClient status() {
-        checkNotNull(status != null, "StatusClient is null");
         return status;
     }
 

--- a/src/main/java/org/hawkular/client/metrics/clients/DefaultAvailabilityClient.java
+++ b/src/main/java/org/hawkular/client/metrics/clients/DefaultAvailabilityClient.java
@@ -16,13 +16,13 @@
  */
 package org.hawkular.client.metrics.clients;
 
-import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
 import javax.ws.rs.core.Response;
 
 import org.hawkular.client.core.BaseClient;
+import org.hawkular.client.core.ClientInfo;
 import org.hawkular.client.core.ClientResponse;
 import org.hawkular.client.core.DefaultClientResponse;
 import org.hawkular.client.core.jaxrs.Empty;
@@ -41,12 +41,8 @@ import com.fasterxml.jackson.databind.JavaType;
 
 public class DefaultAvailabilityClient extends BaseClient<AvailabilityHandler> implements AvailabilityClient {
 
-    public DefaultAvailabilityClient(URI endpointUri) {
-        this(endpointUri, null, null);
-    }
-
-    public DefaultAvailabilityClient(URI endpointUri, String username, String password) {
-        super(endpointUri, username, password, new RestFactory<AvailabilityHandler>(AvailabilityHandler.class));
+    public DefaultAvailabilityClient(ClientInfo clientInfo) {
+        super(clientInfo, new RestFactory<>(AvailabilityHandler.class));
     }
 
     @Override
@@ -57,7 +53,7 @@ public class DefaultAvailabilityClient extends BaseClient<AvailabilityHandler> i
             serverResponse = restApi().findAvailabilityMetrics(tags);
             JavaType javaType = collectionResolver().get(List.class, Metric.class, AvailabilityType.class);
 
-            return new DefaultClientResponse<List<Metric<AvailabilityType>>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -73,7 +69,7 @@ public class DefaultAvailabilityClient extends BaseClient<AvailabilityHandler> i
             serverResponse = restApi().createAvailabilityMetric(overwrite, metric);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_201);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_201);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -89,7 +85,7 @@ public class DefaultAvailabilityClient extends BaseClient<AvailabilityHandler> i
             serverResponse = restApi().addAvailabilityData(data);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -105,7 +101,7 @@ public class DefaultAvailabilityClient extends BaseClient<AvailabilityHandler> i
             serverResponse = restApi().getGaugeTags(tags);
             JavaType javaType = mapResolver().get(Map.class, String.class, List.class, String.class);
 
-            return new DefaultClientResponse<Map<String, List<String>>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -121,7 +117,7 @@ public class DefaultAvailabilityClient extends BaseClient<AvailabilityHandler> i
             serverResponse = restApi().getAvailabilityMetric(id);
             JavaType javaType = simpleResolver().get(Metric.class, AvailabilityType.class);
 
-            return new DefaultClientResponse<Metric<AvailabilityType>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -138,7 +134,7 @@ public class DefaultAvailabilityClient extends BaseClient<AvailabilityHandler> i
             serverResponse = restApi().findAvailabilityData(id, start, end, distinct, limit, order);
             JavaType javaType = collectionResolver().get(List.class, DataPoint.class, AvailabilityType.class);
 
-            return new DefaultClientResponse<List<DataPoint<AvailabilityType>>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -154,7 +150,7 @@ public class DefaultAvailabilityClient extends BaseClient<AvailabilityHandler> i
             serverResponse = restApi().addAvailabilityDataForMetric(id, data);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -171,7 +167,7 @@ public class DefaultAvailabilityClient extends BaseClient<AvailabilityHandler> i
             serverResponse = restApi().findAvailabilityStats(id, start, end, buckets, bucketDuration);
             JavaType javaType = collectionResolver().get(List.class, AvailabilityBucketPoint.class);
 
-            return new DefaultClientResponse<List<AvailabilityBucketPoint>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -187,7 +183,7 @@ public class DefaultAvailabilityClient extends BaseClient<AvailabilityHandler> i
             serverResponse = restApi().getAvailabilityMetricTags(id);
             JavaType javaType = mapResolver().get(Map.class, String.class, String.class);
 
-            return new DefaultClientResponse<Map<String, String>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -203,7 +199,7 @@ public class DefaultAvailabilityClient extends BaseClient<AvailabilityHandler> i
             serverResponse = restApi().updateAvailabilityMetricTags(id, tags);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -219,7 +215,7 @@ public class DefaultAvailabilityClient extends BaseClient<AvailabilityHandler> i
             serverResponse = restApi().deleteAvailabilityMetricTags(id, tags);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();

--- a/src/main/java/org/hawkular/client/metrics/clients/DefaultCounterClient.java
+++ b/src/main/java/org/hawkular/client/metrics/clients/DefaultCounterClient.java
@@ -16,13 +16,13 @@
  */
 package org.hawkular.client.metrics.clients;
 
-import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
 import javax.ws.rs.core.Response;
 
 import org.hawkular.client.core.BaseClient;
+import org.hawkular.client.core.ClientInfo;
 import org.hawkular.client.core.ClientResponse;
 import org.hawkular.client.core.DefaultClientResponse;
 import org.hawkular.client.core.jaxrs.Empty;
@@ -42,12 +42,8 @@ import com.fasterxml.jackson.databind.JavaType;
 
 public class DefaultCounterClient extends BaseClient<CounterHandler> implements CounterClient {
 
-    public DefaultCounterClient(URI endpointUri) {
-        this(endpointUri, null, null);
-    }
-
-    public DefaultCounterClient(URI endpointUri, String username, String password) {
-        super(endpointUri, username, password, new RestFactory<CounterHandler>(CounterHandler.class));
+    public DefaultCounterClient(ClientInfo clientInfo) {
+        super(clientInfo, new RestFactory<>(CounterHandler.class));
     }
 
     @Override
@@ -58,7 +54,7 @@ public class DefaultCounterClient extends BaseClient<CounterHandler> implements 
             serverResponse = restApi().getCounters(tags);
             JavaType javaType = collectionResolver().get(List.class, Metric.class, Long.class);
 
-            return new DefaultClientResponse<List<Metric<Long>>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -74,7 +70,7 @@ public class DefaultCounterClient extends BaseClient<CounterHandler> implements 
             serverResponse = restApi().createCounter(overwrite, metric);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_201);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_201);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -91,7 +87,7 @@ public class DefaultCounterClient extends BaseClient<CounterHandler> implements 
             serverResponse = restApi().findCounterRateDataStats(start, end, bucketsCount, bucketDuration, percentiles, tags, metricNames, stacked);
             JavaType javaType = collectionResolver().get(List.class, NumericBucketPoint.class);
 
-            return new DefaultClientResponse<List<NumericBucketPoint>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -107,7 +103,7 @@ public class DefaultCounterClient extends BaseClient<CounterHandler> implements 
             serverResponse = restApi().addCounterData(counters);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -124,7 +120,7 @@ public class DefaultCounterClient extends BaseClient<CounterHandler> implements 
             serverResponse = restApi().findCounterStats(start, end, bucketsCount, bucketDuration, percentiles, tags, metricNames, stacked);
             JavaType javaType = collectionResolver().get(List.class, NumericBucketPoint.class);
 
-            return new DefaultClientResponse<List<NumericBucketPoint>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -140,7 +136,7 @@ public class DefaultCounterClient extends BaseClient<CounterHandler> implements 
             serverResponse = restApi().findCounterMetrics(tags);
             JavaType javaType = mapResolver().get(Map.class, String.class, List.class, String.class);
 
-            return new DefaultClientResponse<Map<String, List<String>>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -156,7 +152,7 @@ public class DefaultCounterClient extends BaseClient<CounterHandler> implements 
             serverResponse = restApi().getCounter(id);
             JavaType javaType = simpleResolver().get(Metric.class, Long.class);
 
-            return new DefaultClientResponse<Metric<Long>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -173,7 +169,7 @@ public class DefaultCounterClient extends BaseClient<CounterHandler> implements 
             serverResponse = restApi().findCounterRate(id, start, end, limit, order, bucketsCount, bucketDuration, percentiles);
             JavaType javaType = collectionResolver().get(List.class, NumericBucketPoint.class);
 
-            return new DefaultClientResponse<List<NumericBucketPoint>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -190,7 +186,7 @@ public class DefaultCounterClient extends BaseClient<CounterHandler> implements 
             serverResponse = restApi().findCounterRateStats(id, start, end, bucketsCount, bucketDuration, percentiles);
             JavaType javaType = collectionResolver().get(List.class, NumericBucketPoint.class);
 
-            return new DefaultClientResponse<List<NumericBucketPoint>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -206,7 +202,7 @@ public class DefaultCounterClient extends BaseClient<CounterHandler> implements 
             serverResponse = restApi().findCounterData(id, start, end, limit, order);
             JavaType javaType = collectionResolver().get(List.class, DataPoint.class, Long.class);
 
-            return new DefaultClientResponse<List<DataPoint<Long>>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -222,7 +218,7 @@ public class DefaultCounterClient extends BaseClient<CounterHandler> implements 
             serverResponse = restApi().createCounterData(id, data);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -239,7 +235,7 @@ public class DefaultCounterClient extends BaseClient<CounterHandler> implements 
             serverResponse = restApi().findCounterMetricStats(id, start, end, fromEarliest, bucketsCount, bucketDuration, percentiles, limit, order);
             JavaType javaType = collectionResolver().get(List.class, NumericBucketPoint.class);
 
-            return new DefaultClientResponse<List<NumericBucketPoint>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -255,7 +251,7 @@ public class DefaultCounterClient extends BaseClient<CounterHandler> implements 
             serverResponse = restApi().getCounterMetricStatsTags(id, tags, start, end, percentiles);
             JavaType javaType = mapResolver().get(Map.class, String.class, TaggedBucketPoint.class);
 
-            return new DefaultClientResponse<Map<String, TaggedBucketPoint>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -271,7 +267,7 @@ public class DefaultCounterClient extends BaseClient<CounterHandler> implements 
             serverResponse = restApi().getCounterMetricTags(id);
             JavaType javaType = mapResolver().get(Map.class, String.class, String.class);
 
-            return new DefaultClientResponse<Map<String, String>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -287,7 +283,7 @@ public class DefaultCounterClient extends BaseClient<CounterHandler> implements 
             serverResponse = restApi().updateCountersMetricTags(id, tags);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -303,7 +299,7 @@ public class DefaultCounterClient extends BaseClient<CounterHandler> implements 
             serverResponse = restApi().deleteCounterMetricTags(id, tags);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();

--- a/src/main/java/org/hawkular/client/metrics/clients/DefaultGaugeClient.java
+++ b/src/main/java/org/hawkular/client/metrics/clients/DefaultGaugeClient.java
@@ -16,13 +16,13 @@
  */
 package org.hawkular.client.metrics.clients;
 
-import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
 import javax.ws.rs.core.Response;
 
 import org.hawkular.client.core.BaseClient;
+import org.hawkular.client.core.ClientInfo;
 import org.hawkular.client.core.ClientResponse;
 import org.hawkular.client.core.DefaultClientResponse;
 import org.hawkular.client.core.jaxrs.Empty;
@@ -42,12 +42,8 @@ import com.fasterxml.jackson.databind.JavaType;
 
 public class DefaultGaugeClient extends BaseClient<GaugeHandler> implements GaugeClient {
 
-    public DefaultGaugeClient(URI endpointUri) {
-        this(endpointUri, null, null);
-    }
-
-    public DefaultGaugeClient(URI endpointUri, String username, String password) {
-        super(endpointUri, username, password, new RestFactory<GaugeHandler>(GaugeHandler.class));
+    public DefaultGaugeClient(ClientInfo clientInfo) {
+        super(clientInfo, new RestFactory<>(GaugeHandler.class));
     }
 
     @Override
@@ -58,7 +54,7 @@ public class DefaultGaugeClient extends BaseClient<GaugeHandler> implements Gaug
             serverResponse = restApi().findGaugeMetrics(tags);
             JavaType javaType = collectionResolver().get(List.class, Metric.class, Double.class);
 
-            return new DefaultClientResponse<List<Metric<Double>>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -74,7 +70,7 @@ public class DefaultGaugeClient extends BaseClient<GaugeHandler> implements Gaug
             serverResponse = restApi().createGaugeMetric(overwrite, metric);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_201);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_201);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -91,7 +87,7 @@ public class DefaultGaugeClient extends BaseClient<GaugeHandler> implements Gaug
             serverResponse = restApi().findGaugeRateStats(start, end, bucketsCount, bucketDuration, percentiles, tags, metricNames, stacked);
             JavaType javaType = collectionResolver().get(List.class, NumericBucketPoint.class);
 
-            return new DefaultClientResponse<List<NumericBucketPoint>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -107,7 +103,7 @@ public class DefaultGaugeClient extends BaseClient<GaugeHandler> implements Gaug
             serverResponse = restApi().addGaugeData(gauges);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -124,7 +120,7 @@ public class DefaultGaugeClient extends BaseClient<GaugeHandler> implements Gaug
             serverResponse = restApi().findGaugeStats(start, end, bucketsCount, bucketDuration, percentiles, tags, metricNames, stacked);
             JavaType javaType = collectionResolver().get(List.class, NumericBucketPoint.class);
 
-            return new DefaultClientResponse<List<NumericBucketPoint>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -140,7 +136,7 @@ public class DefaultGaugeClient extends BaseClient<GaugeHandler> implements Gaug
             serverResponse = restApi().getGaugeMetricTagValues(tags);
             JavaType javaType = mapResolver().get(Map.class, String.class, List.class, String.class);
 
-            return new DefaultClientResponse<Map<String, List<String>>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -156,7 +152,7 @@ public class DefaultGaugeClient extends BaseClient<GaugeHandler> implements Gaug
             serverResponse = restApi().getGaugeMetric(id);
             JavaType javaType = simpleResolver().get(Metric.class, Double.class);
 
-            return new DefaultClientResponse<Metric<Double>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -172,7 +168,7 @@ public class DefaultGaugeClient extends BaseClient<GaugeHandler> implements Gaug
             serverResponse = restApi().findGaugeDataPeriods(id, start, end, threshold, operator);
             JavaType javaType = collectionResolver().get(List.class, Long[].class);
 
-            return new DefaultClientResponse<List<Long[]>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -188,7 +184,7 @@ public class DefaultGaugeClient extends BaseClient<GaugeHandler> implements Gaug
             serverResponse = restApi().getGaugeRate(id, start, end, limit, order);
             JavaType javaType = collectionResolver().get(List.class, DataPoint.class, Double.class);
 
-            return new DefaultClientResponse<List<DataPoint<Double>>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -205,7 +201,7 @@ public class DefaultGaugeClient extends BaseClient<GaugeHandler> implements Gaug
             serverResponse = restApi().getGaugeRateStats(id, start, end, bucketsCount, bucketDuration, percentiles);
             JavaType javaType = collectionResolver().get(List.class, NumericBucketPoint.class);
 
-            return new DefaultClientResponse<List<NumericBucketPoint>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -222,7 +218,7 @@ public class DefaultGaugeClient extends BaseClient<GaugeHandler> implements Gaug
             serverResponse = restApi().findGaugeDataWithId(id, start, end, fromEarliest, limit, order);
             JavaType javaType = collectionResolver().get(List.class, DataPoint.class, Double.class);
 
-            return new DefaultClientResponse<List<DataPoint<Double>>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -238,7 +234,7 @@ public class DefaultGaugeClient extends BaseClient<GaugeHandler> implements Gaug
             serverResponse = restApi().addGaugeDataForMetric(id, data);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -255,7 +251,7 @@ public class DefaultGaugeClient extends BaseClient<GaugeHandler> implements Gaug
             serverResponse = restApi().getGaugeStats(id, start, end, fromEarliest, bucketsCount, bucketDuration, percentiles);
             JavaType javaType = collectionResolver().get(List.class, NumericBucketPoint.class);
 
-            return new DefaultClientResponse<List<NumericBucketPoint>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -271,7 +267,7 @@ public class DefaultGaugeClient extends BaseClient<GaugeHandler> implements Gaug
             serverResponse = restApi().getGaugeStatsTags(id, tags, start, end, percentiles);
             JavaType javaType = mapResolver().get(Map.class, String.class, TaggedBucketPoint.class);
 
-            return new DefaultClientResponse<Map<String, TaggedBucketPoint>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -287,7 +283,7 @@ public class DefaultGaugeClient extends BaseClient<GaugeHandler> implements Gaug
             serverResponse = restApi().getGaugeMetricTags(id);
             JavaType javaType = mapResolver().get(Map.class, String.class, String.class);
 
-            return new DefaultClientResponse<Map<String, String>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -303,7 +299,7 @@ public class DefaultGaugeClient extends BaseClient<GaugeHandler> implements Gaug
             serverResponse = restApi().updateGaugeMetricTags(id, tags);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.UPDATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -319,7 +315,7 @@ public class DefaultGaugeClient extends BaseClient<GaugeHandler> implements Gaug
             serverResponse = restApi().deleteGaugeMetricTags(id, tags);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();

--- a/src/main/java/org/hawkular/client/metrics/clients/DefaultMetricClient.java
+++ b/src/main/java/org/hawkular/client/metrics/clients/DefaultMetricClient.java
@@ -16,13 +16,13 @@
  */
 package org.hawkular.client.metrics.clients;
 
-import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
 import javax.ws.rs.core.Response;
 
 import org.hawkular.client.core.BaseClient;
+import org.hawkular.client.core.ClientInfo;
 import org.hawkular.client.core.ClientResponse;
 import org.hawkular.client.core.DefaultClientResponse;
 import org.hawkular.client.core.jaxrs.Empty;
@@ -38,12 +38,8 @@ import com.fasterxml.jackson.databind.JavaType;
 
 public class DefaultMetricClient extends BaseClient<MetricHandler> implements MetricClient {
 
-    public DefaultMetricClient(URI endpointUri) {
-        this(endpointUri, null, null);
-    }
-
-    public DefaultMetricClient(URI endpointUri, String username, String password) {
-        super(endpointUri, username, password, new RestFactory<MetricHandler>(MetricHandler.class));
+    public DefaultMetricClient(ClientInfo clientInfo) {
+        super(clientInfo, new RestFactory<>(MetricHandler.class));
     }
 
     @Override
@@ -54,7 +50,7 @@ public class DefaultMetricClient extends BaseClient<MetricHandler> implements Me
             serverResponse = restApi().findMetrics(metricType, tags, id);
             JavaType javaType = collectionResolver().get(List.class, Metric.class);
 
-            return new DefaultClientResponse<List<Metric<?>>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -71,7 +67,7 @@ public class DefaultMetricClient extends BaseClient<MetricHandler> implements Me
             serverResponse = restApi().createMetric(overwrite, metric);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_201);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_201);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -87,7 +83,7 @@ public class DefaultMetricClient extends BaseClient<MetricHandler> implements Me
             serverResponse = restApi().addMetricsData(metricsRequest);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -103,7 +99,7 @@ public class DefaultMetricClient extends BaseClient<MetricHandler> implements Me
             serverResponse = restApi().findMetricsTags(tags, metricType);
             JavaType javaType = mapResolver().get(Map.class, String.class, List.class, String.class);
 
-            return new DefaultClientResponse<Map<String, List<String>>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();

--- a/src/main/java/org/hawkular/client/metrics/clients/DefaultPingClient.java
+++ b/src/main/java/org/hawkular/client/metrics/clients/DefaultPingClient.java
@@ -16,12 +16,12 @@
  */
 package org.hawkular.client.metrics.clients;
 
-import java.net.URI;
 import java.util.Map;
 
 import javax.ws.rs.core.Response;
 
 import org.hawkular.client.core.BaseClient;
+import org.hawkular.client.core.ClientInfo;
 import org.hawkular.client.core.ClientResponse;
 import org.hawkular.client.core.DefaultClientResponse;
 import org.hawkular.client.core.jaxrs.ResponseCodes;
@@ -32,12 +32,8 @@ import com.fasterxml.jackson.databind.JavaType;
 
 public class DefaultPingClient extends BaseClient<PingHandler> implements PingClient {
 
-    public DefaultPingClient(URI endpointUri) {
-        this(endpointUri, null, null);
-    }
-
-    public DefaultPingClient(URI endpointUri, String username, String password) {
-        super(endpointUri, username, password, new RestFactory<PingHandler>(PingHandler.class));
+    public DefaultPingClient(ClientInfo clientInfo) {
+        super(clientInfo, new RestFactory<>(PingHandler.class));
     }
 
     @Override
@@ -48,7 +44,7 @@ public class DefaultPingClient extends BaseClient<PingHandler> implements PingCl
             serverResponse = restApi().ping();
             JavaType javaType = mapResolver().get(Map.class, String.class, String.class);
 
-            return new DefaultClientResponse<Map<String, String>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();

--- a/src/main/java/org/hawkular/client/metrics/clients/DefaultStatusClient.java
+++ b/src/main/java/org/hawkular/client/metrics/clients/DefaultStatusClient.java
@@ -16,12 +16,12 @@
  */
 package org.hawkular.client.metrics.clients;
 
-import java.net.URI;
 import java.util.Map;
 
 import javax.ws.rs.core.Response;
 
 import org.hawkular.client.core.BaseClient;
+import org.hawkular.client.core.ClientInfo;
 import org.hawkular.client.core.ClientResponse;
 import org.hawkular.client.core.DefaultClientResponse;
 import org.hawkular.client.core.jaxrs.ResponseCodes;
@@ -32,12 +32,8 @@ import com.fasterxml.jackson.databind.JavaType;
 
 public class DefaultStatusClient extends BaseClient<StatusHandler> implements StatusClient {
 
-    public DefaultStatusClient(URI endpointUri) {
-        this(endpointUri, null, null);
-    }
-
-    public DefaultStatusClient(URI endpointUri, String username, String password) {
-        super(endpointUri, username, password, new RestFactory<StatusHandler>(StatusHandler.class));
+    public DefaultStatusClient(ClientInfo clientInfo) {
+        super(clientInfo, new RestFactory<>(StatusHandler.class));
     }
 
     @Override
@@ -48,7 +44,7 @@ public class DefaultStatusClient extends BaseClient<StatusHandler> implements St
             serverResponse = restApi().status();
             JavaType javaType = mapResolver().get(Map.class, String.class, String.class);
 
-            return new DefaultClientResponse<Map<String, String>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();

--- a/src/main/java/org/hawkular/client/metrics/clients/DefaultStringClient.java
+++ b/src/main/java/org/hawkular/client/metrics/clients/DefaultStringClient.java
@@ -16,13 +16,13 @@
  */
 package org.hawkular.client.metrics.clients;
 
-import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
 import javax.ws.rs.core.Response;
 
 import org.hawkular.client.core.BaseClient;
+import org.hawkular.client.core.ClientInfo;
 import org.hawkular.client.core.ClientResponse;
 import org.hawkular.client.core.DefaultClientResponse;
 import org.hawkular.client.core.jaxrs.Empty;
@@ -38,12 +38,8 @@ import com.fasterxml.jackson.databind.JavaType;
 
 public class DefaultStringClient extends BaseClient<StringHandler> implements StringClient {
 
-    public DefaultStringClient(URI endpointUri) {
-        this(endpointUri, null, null);
-    }
-
-    public DefaultStringClient(URI endpointUri, String username, String password) {
-        super(endpointUri, username, password, new RestFactory<StringHandler>(StringHandler.class));
+    public DefaultStringClient(ClientInfo clientInfo) {
+        super(clientInfo, new RestFactory<>(StringHandler.class));
     }
 
     @Override
@@ -54,7 +50,7 @@ public class DefaultStringClient extends BaseClient<StringHandler> implements St
             serverResponse = restApi().findMetricsDefinitions(tags);
             JavaType javaType = collectionResolver().get(List.class, Metric.class);
 
-            return new DefaultClientResponse<List<Metric>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -70,7 +66,7 @@ public class DefaultStringClient extends BaseClient<StringHandler> implements St
             serverResponse = restApi().createStringMetric(overwrite, metric);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_201);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_201);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -86,7 +82,7 @@ public class DefaultStringClient extends BaseClient<StringHandler> implements St
             serverResponse = restApi().createStringMetric(metrics);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -102,7 +98,7 @@ public class DefaultStringClient extends BaseClient<StringHandler> implements St
             serverResponse = restApi().findMetricTags(tags);
             JavaType javaType = mapResolver().get(Map.class, String.class, List.class, String.class);
 
-            return new DefaultClientResponse<Map<String, List<String>>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -118,7 +114,7 @@ public class DefaultStringClient extends BaseClient<StringHandler> implements St
             serverResponse = restApi().getMetricDefinitions(id);
             JavaType javaType = simpleResolver().get(Metric.class);
 
-            return new DefaultClientResponse<Metric>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -135,7 +131,7 @@ public class DefaultStringClient extends BaseClient<StringHandler> implements St
             serverResponse = restApi().getMetricDefinitionsData(id, start, end, distinct, limit, order);
             JavaType javaType = collectionResolver().get(List.class, DataPoint.class);
 
-            return new DefaultClientResponse<List<DataPoint>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -151,7 +147,7 @@ public class DefaultStringClient extends BaseClient<StringHandler> implements St
             serverResponse = restApi().createMetricDefinitionsData(id, dataPoints);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -167,7 +163,7 @@ public class DefaultStringClient extends BaseClient<StringHandler> implements St
             serverResponse = restApi().findMetricDefinitionsTags(id);
             JavaType javaType = mapResolver().get(Map.class, String.class, String.class);
 
-            return new DefaultClientResponse<Map<String, String>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -183,7 +179,7 @@ public class DefaultStringClient extends BaseClient<StringHandler> implements St
             serverResponse = restApi().updateMetricDefinitionsTags(id, tags);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -199,7 +195,7 @@ public class DefaultStringClient extends BaseClient<StringHandler> implements St
             serverResponse = restApi().deleteMetricDefinitionsTags(id, tags);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.DELETE_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();

--- a/src/main/java/org/hawkular/client/metrics/clients/DefaultTenantClient.java
+++ b/src/main/java/org/hawkular/client/metrics/clients/DefaultTenantClient.java
@@ -16,12 +16,12 @@
  */
 package org.hawkular.client.metrics.clients;
 
-import java.net.URI;
 import java.util.List;
 
 import javax.ws.rs.core.Response;
 
 import org.hawkular.client.core.BaseClient;
+import org.hawkular.client.core.ClientInfo;
 import org.hawkular.client.core.ClientResponse;
 import org.hawkular.client.core.DefaultClientResponse;
 import org.hawkular.client.core.jaxrs.Empty;
@@ -34,12 +34,8 @@ import com.fasterxml.jackson.databind.JavaType;
 
 public class DefaultTenantClient extends BaseClient<TenantHandler> implements TenantClient {
 
-    public DefaultTenantClient(URI endpointUri) {
-        this(endpointUri, null, null);
-    }
-
-    public DefaultTenantClient(URI endpointUri, String username, String password) {
-        super(endpointUri, username, password, new RestFactory<TenantHandler>(TenantHandler.class));
+    public DefaultTenantClient(ClientInfo clientInfo) {
+        super(clientInfo, new RestFactory<>(TenantHandler.class));
     }
 
     @Override
@@ -50,7 +46,7 @@ public class DefaultTenantClient extends BaseClient<TenantHandler> implements Te
             serverResponse = restApi().getTenants();
             JavaType javaType = collectionResolver().get(List.class, Tenant.class);
 
-            return new DefaultClientResponse<List<Tenant>>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.GET_SUCCESS_200);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();
@@ -66,7 +62,7 @@ public class DefaultTenantClient extends BaseClient<TenantHandler> implements Te
             serverResponse = restApi().createTenant(overwrite, tenant);
             JavaType javaType = simpleResolver().get(Empty.class);
 
-            return new DefaultClientResponse<Empty>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_201);
+            return new DefaultClientResponse<>(javaType, serverResponse, ResponseCodes.CREATE_SUCCESS_201);
         } finally {
             if (serverResponse != null) {
                 serverResponse.close();

--- a/src/test/java/org/hawkular/client/test/BaseTest.java
+++ b/src/test/java/org/hawkular/client/test/BaseTest.java
@@ -18,7 +18,6 @@ package org.hawkular.client.test;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.HashMap;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hawkular.client.core.HawkularClient;
@@ -27,7 +26,7 @@ import org.testng.annotations.BeforeClass;
 
 public class BaseTest {
 
-    public static final long MINUTE = 1000 * 60;
+    protected static final long MINUTE = 1000 * 60;
     public static final String HEADER_TENANT = "unit-testing";
 
     private HawkularClient client;
@@ -37,10 +36,10 @@ public class BaseTest {
         URI endpoint = getEndpointFromEnv();
         Reporter.log(endpoint.toString());
 
-        HashMap<String, Object> headers = new HashMap<String, Object>();
-        headers.put(HawkularClient.KEY_HEADER_TENANT, HEADER_TENANT);
-
-        client = new HawkularClient(endpoint, getUsername(), getPassword(), headers);
+        client = HawkularClient.builder(HEADER_TENANT)
+                .uri(endpoint)
+                .basicAuthentication(getUsername(), getPassword())
+                .build();
     }
 
     private URI getEndpointFromEnv() throws URISyntaxException {

--- a/src/test/java/org/hawkular/client/test/metrics/MetricTest.java
+++ b/src/test/java/org/hawkular/client/test/metrics/MetricTest.java
@@ -16,10 +16,8 @@
  */
 package org.hawkular.client.test.metrics;
 
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -135,9 +133,9 @@ public class MetricTest extends BaseTest {
     @Test(dependsOnMethods = "findMetrics")
     public void findMetricsAfterOtherClientCreated() throws URISyntaxException {
         // Make sure there's no breaking static config
-        HashMap<String, Object> headers = new HashMap<>();
-        headers.put(HawkularClient.KEY_HEADER_TENANT, "other tenant");
-        HawkularClient otherClient = new HawkularClient(new URI("fake"), null, null, headers);
+        HawkularClient otherClient = HawkularClient.builder("other tenant")
+                .uri("http://localhost:8080/fake")
+                .build();
 
         ClientResponse<List<Metric<?>>> response = client()
                 .metrics()


### PR DESCRIPTION
Create builder

Previously headers were store statically, which led to bugs or complicated update/remove operations when we want to use several clients in the same application.

Remove also some useless Preconditions checkArguments, and add some others

Introduce parameter object for all API-classes constructors
